### PR TITLE
Removed hash from amazon_core_service.c

### DIFF
--- a/amazon_core_service.c
+++ b/amazon_core_service.c
@@ -11,7 +11,6 @@ int main() {
 }
 
 void secretAmazonService() {
-    // # Hash 3
     // # Hash 4
     // # Hash 5
     // # Hash 6


### PR DESCRIPTION
Removed a # from the codebase as part of the Great Hashtag Removal Challenge.